### PR TITLE
Add attribution: This repository copies significant portions of https://github.com/mike42/escpos-php

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Xiidea
+Copyright (c) 2014 Michael Billington <michael.billington@gmail.com>,
+  with additions and modifications by Xiidea
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ $printer -> cut();
 
 ```
 
+Attribution
+-----------
+This library is a modified version of escpos-php, a Library to work with ESC/POS thermal printers, implemented by Michael Billington. Further documentation is available at [https://github.com/mike42/escpos-php](https://github.com/mike42/escpos-php).
 
 Reference
 ==========

--- a/src/Epson/EscPos.php
+++ b/src/Epson/EscPos.php
@@ -5,8 +5,26 @@
  * Class holding all ESC/POS constants
  *
  * @package		ESC/POS command SDK
- * @author		Roni Saha <roni.cse@gmail.com>
+ * @author		Michael Billington <michael.billington@gmail.com>,
+ *			modifications by Roni Saha <roni.cse@gmail.com>
  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 namespace Epson;
 

--- a/src/Epson/Printer.php
+++ b/src/Epson/Printer.php
@@ -6,10 +6,27 @@
  *
  * @package		ESC/POS command SDK
  * @category	Main Class
- * @author		Roni Saha <roni.cse@gmail.com>
+ * @author		Michael Billington <michael.billington@gmail.com>,
+ *			modifications by Roni Saha <roni.cse@gmail.com>
  *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
-
 namespace Epson;
 
 use Epson\Devices\Device;


### PR DESCRIPTION
This repository, in its current form, infringes copyright.

The "Initial Implementation" contains code for generating print commands in EscPos.php and Printer.php:
- https://github.com/xiidea/php-esc-pos/commit/0827b5f54e8688a0c62761b5cbe6ecfefc1c2810

This is a copy of code which I wrote and published some 6 months earlier:
- https://github.com/mike42/escpos-php/blob/d7383a3fb5df173a5daa5e6b7030b58e1d4b5b8c/escpos.php

As this code has since been MIT-licensed, it would be fine for you to use it, provided that you correctly attribute it. I've created a pull request which will acknowledge the source and copyright status of the code, in order to comply with the licensing terms.

To fix this issue, please accept this pull request.
